### PR TITLE
Fix docstring typo

### DIFF
--- a/hello_world_mcp/server.py
+++ b/hello_world_mcp/server.py
@@ -12,7 +12,7 @@ mcp = FastMCP(name="HelloWorldMCP",
 
 @mcp.tool()
 def hello_world(name: str) -> str:
-    """Greet a user Hellow World!"""
+    """Greet a user Hello World!"""
     return f"Hello World, {name}!"
 
 @mcp.tool()


### PR DESCRIPTION
## Summary
- fix a typo in the hello_world tool's docstring
- ensure `hello_world_mcp/server.py` ends with a newline

## Testing
- `git status --short`