### PR TITLE
Add basic test for hello_world function

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -1,0 +1,26 @@
+name: Run Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "0.5.11"
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: "pyproject.toml"
+      - name: Install dependencies
+        run: uv sync --all-extras --dev
+      - name: Run tests
+        run: uv run pytest -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,4 +17,5 @@ hello_world_mcp = { workspace = true }
 [dependency-groups]
 dev = [
     "hello_world_mcp",
+    "pytest>=8.2.0",
 ]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,4 @@
+from hello_world_mcp.server import hello_world
+
+def test_hello_world():
+    assert hello_world('Alice') == "Hello World, Alice!"


### PR DESCRIPTION
## Summary
- add CI to run tests using `uv`
- create a minimal test for the `hello_world` function
- list `pytest` in dev dependencies

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*