### PR TITLE
Add license headers and project metadata

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @lukasmosser

--- a/hello_world_mcp/hello_world_mcp/__init__.py
+++ b/hello_world_mcp/hello_world_mcp/__init__.py
@@ -1,0 +1,16 @@
+"""
+Package initialization for hello_world_mcp.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License in the LICENSE file at the
+root of this repository or at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+

--- a/hello_world_mcp/server.py
+++ b/hello_world_mcp/server.py
@@ -1,3 +1,19 @@
+"""
+This file is part of the EAGE Hackathon 2025 project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License in the LICENSE file at the
+root of this repository or at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 from fastmcp import FastMCP, Image
 from starlette.requests import Request
 from starlette.responses import JSONResponse

--- a/modal_mcp_servers.py
+++ b/modal_mcp_servers.py
@@ -1,3 +1,19 @@
+"""
+Modal server definitions for the EAGE Hackathon 2025 project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License in the LICENSE file at the
+root of this repository or at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 import modal
 
 app = modal.App("eage-annual-2025-mcp-server")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,3 +1,19 @@
+"""
+Test cases for the hello_world function.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License in the LICENSE file at the
+root of this repository or at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 from hello_world_mcp.server import hello_world
 
 def test_hello_world():


### PR DESCRIPTION
## Summary
- add CODEOWNERS with maintainer handle
- set automatic text handling through `.gitattributes`
- insert Apache 2.0 license headers into source files

## Testing
- `pytest -q` *(fails: command not found)*