### PR TITLE
Add devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,10 @@
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+
+# Install git (required for pre-commit)
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+
+# Set environment to output logs immediately
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONIOENCODING=UTF-8
+
+WORKDIR /workspace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+    "name": "EAGE Hackathon Dev Container",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "postCreateCommand": "uv sync --groups dev && pre-commit install",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-python.python",
+                "ms-python.vscode-pylance",
+                "ms-azuretools.vscode-docker",
+                "github.copilot",
+                "github.copilot-chat"
+            ]
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `.devcontainer` folder with Dockerfile and `devcontainer.json`
- devcontainer installs Git, syncs dev dependencies and registers pre-commit
- enable useful extensions for Python and GitHub Copilot

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest` *(fails: command not found)*